### PR TITLE
Condor Ready + Script Fix

### DIFF
--- a/MC_generation/PbPb_its_condor.sub
+++ b/MC_generation/PbPb_its_condor.sub
@@ -10,8 +10,8 @@ request_memory = 4096
 request_disk = 8192000
 
 
-executable              = generate_its.sh
-arguments               = 2 1 20 $(ClusterId) $(ProcId) 
+executable              = eos_generate_its.sh
+arguments               = 2 1 100 $(ClusterId) $(ProcId) 
 #ClusterID = Job ID. ProcID: Subprocess ID, useful for scripting
 
 output                  = job.$(ClusterId).$(ProcId).out

--- a/MC_generation/condor_generate_its.sh
+++ b/MC_generation/condor_generate_its.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+/cvmfs/alice.cern.ch/bin/alienv enter O2/nightly-20210129-1
 eos_dir="/eos/user/f/ftorales/its_data/alignment/lbnl_alice_alignment_tasks"
 echo "==============================="
 echo "execute this script as follows:"

--- a/MC_generation/eos_generate_its.sh
+++ b/MC_generation/eos_generate_its.sh
@@ -1,4 +1,7 @@
 #! /bin/bash
+#/cvmfs/alice.cern.ch/bin/alienv enter O2/nightly-20210129-1
+eval "$(/cvmfs/alice.cern.ch/bin/alienv printenv O2::nightly-20210129-1)"
+eos_dir="/eos/user/f/ftorales/its_data/alignment/lbnl_alice_alignment_tasks"
 echo "==============================="
 echo "execute this script as follows:"
 echo "./generate_its.sh system region nevents"
@@ -58,6 +61,12 @@ fi
 # --------------
 # parameter 3
 echo "Will generate: "$(($3))" events"
+# -------------
+# parameter 4&5
+echo "Moving to ${eos_dir}/${4}/${5}"
+mkdir -p $eos_dir/$4/$5/
+cd $eos_dir/$4/$5/
+pwd
 # ----------------------------------------------------------
 # 1. MC GENERATION RUN
 echo ""

--- a/MC_generation/pp_its_condor.sub
+++ b/MC_generation/pp_its_condor.sub
@@ -10,8 +10,8 @@ request_memory = 4096
 request_disk = 8192000
 
 
-executable              = generate_its.sh
-arguments               = 1 1 20 $(ClusterId) $(ProcId) 
+executable              = eos_generate_its.sh
+arguments               = 1 1 100 $(ClusterId) $(ProcId) 
 #ClusterID = Job ID. ProcID: Subprocess ID, useful for scripting
 
 output                  = job.$(ClusterId).$(ProcId).out

--- a/condor_generate_its.sh
+++ b/condor_generate_its.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+/cvmfs/alice.cern.ch/bin/alienv enter O2/nightly-20210129-1
 eos_dir="/eos/user/f/ftorales/its_data/alignment/lbnl_alice_alignment_tasks"
 echo "==============================="
 echo "execute this script as follows:"


### PR DESCRIPTION
using cvmfs eval to enter o2 environment and run o2 commands
- previous alienv enter command did not allow for commands to be run after entering environment

Updated .sub files to 100 events. Ran 20 jobs at 100 events each for pp and PbPb overnight

Fixed .sh files to parse arguments correctly
- $2 now indicitase detecter specification, $3 now indicates n_events
- $1 previously used second time for detecter specification, $2 used for n_events ( this made it so that it previously produced only 1 or 2 events haha)